### PR TITLE
Hide status bar during emulation - EmulationViewController.mm

### DIFF
--- a/Source/iOS/App/Common/UI/Emulation/EmulationViewController.mm
+++ b/Source/iOS/App/Common/UI/Emulation/EmulationViewController.mm
@@ -146,6 +146,10 @@
   self.additionalSafeAreaInsets = insets;
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
+
 - (void)stopPressed {
   void (^stop)() = ^{
     Host_Message(HostMessageID::WMUserStop);


### PR DESCRIPTION
The status bar was still visible in dark mode and left a black bar wasting space on light mode.
Simply added `prefersStatusBarHidden` to the EmulationViewController.mm.
Fixes #54 