### PR TITLE
InputCommon: fix keyboards not being listed in devices

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/iOS/MFiControllerScanner.h
+++ b/Source/Core/InputCommon/ControllerInterface/iOS/MFiControllerScanner.h
@@ -7,4 +7,6 @@
 
 @interface MFiControllerScanner : NSObject
 
+@property (nonatomic, strong) NSMutableArray* keyboards;
+
 @end

--- a/Source/Core/InputCommon/ControllerInterface/iOS/MFiControllerScanner.mm
+++ b/Source/Core/InputCommon/ControllerInterface/iOS/MFiControllerScanner.mm
@@ -15,6 +15,8 @@
 {
   if (self = [super init])
   {
+    _keyboards = [[NSMutableArray alloc] init];
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(controllerConnected:)
                                                  name:GCControllerDidConnectNotification
@@ -61,6 +63,7 @@
 {
   GCKeyboard* keyboard = (GCKeyboard*)notification.object;
   g_controller_interface.AddDevice(std::make_shared<ciface::iOS::MFiKeyboard>(keyboard));
+  [_keyboards addObject:keyboard];
 }
 
 - (void)keyboardDisconnected:(NSNotification*)notification
@@ -70,6 +73,7 @@
         dynamic_cast<const ciface::iOS::MFiKeyboard*>(device);
     return keyboard != nullptr;
   });
+  [_keyboards removeObject:notification.object];
 }
 
 @end

--- a/Source/Core/InputCommon/ControllerInterface/iOS/iOS.mm
+++ b/Source/Core/InputCommon/ControllerInterface/iOS/iOS.mm
@@ -5,6 +5,7 @@
 
 #include "InputCommon/ControllerInterface/iOS/MFiController.h"
 #include "InputCommon/ControllerInterface/iOS/MFiControllerScanner.h"
+#include "InputCommon/ControllerInterface/iOS/MFiKeyboard.h"
 #include "InputCommon/ControllerInterface/iOS/StateManager.h"
 #include "InputCommon/ControllerInterface/iOS/Touchscreen.h"
 
@@ -49,5 +50,8 @@ void InputBackend::PopulateDevices()
   
   for (GCController* controller in [GCController controllers])
     g_controller_interface.AddDevice(std::make_shared<MFiController>(controller));
+
+  for (GCKeyboard* keyboard in [m_mfi_scanner keyboards])
+    g_controller_interface.AddDevice(std::make_shared<MFiKeyboard>(keyboard));
 }
 }  // namespace ciface::iOS


### PR DESCRIPTION
Keyboards were previously not listed as input devices. Unfortunately, there is no `[GCKeyboard keyboards]` as with controllers (`[GCController controllers]`), so the keyboards need to be kept track of manually.