### PR TITLE
Add StikJIT for in-app JIT enablement on iOS 17.4+

### DIFF
--- a/.github/workflows/unsignedipa.yml
+++ b/.github/workflows/unsignedipa.yml
@@ -1,0 +1,92 @@
+name: Build & Upload Unsigned IPAs
+
+on:
+  push:
+  workflow_dispatch:
+
+concurrency:
+  group: unsignedipa-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository_owner != 'OatmealDome'
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - beta: false
+            variant: njb
+            configuration: Release (Non-Jailbroken)
+            scheme: DiOS (NJB)
+            archive_name: NonJailbroken
+            output_name: DiOS-Non-Jailbroken.ipa
+          - beta: false
+            variant: trollstore
+            configuration: Release (TrollStore)
+            scheme: DiOS (JB)
+            archive_name: TrollStore
+            output_name: DiOS-TrollStore.tipa
+          - beta: true
+            variant: njb
+            configuration: Release (Beta, Non-Jailbroken)
+            scheme: DiOS (NJB)
+            archive_name: NonJailbroken-Beta
+            output_name: DiOS-Non-Jailbroken-Beta.ipa
+          - beta: true
+            variant: trollstore
+            configuration: Release (Beta, TrollStore)
+            scheme: DiOS (JB)
+            archive_name: TrollStore-Beta
+            output_name: DiOS-TrollStore-Beta.tipa
+
+    env:
+      XCODE_COMMON_BUILD_ARGS: -project Source/iOS/App/DolphiniOS.xcodeproj -derivedDataPath "${{ github.workspace }}/build-Xcode" -sdk iphoneos -destination generic/platform=iOS DOL_PBID_ORGANIZATION_IDENTIFIER="me.${{ github.repository_owner }}" DOL_BUILD_SOURCE="development" CODE_SIGNING_ALLOWED="NO" CODE_SIGNING_REQUIRED="NO"
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: irgaly/xcode-cache@v1
+        with:
+          key: xcode-cache-deriveddata-${{ runner.os }}-${{ matrix.beta }}-${{ matrix.variant }}-${{ hashFiles('Source/iOS/App/DolphiniOS.xcodeproj/project.pbxproj', '**/Package.resolved') }}
+          restore-keys: |
+            xcode-cache-deriveddata-${{ runner.os }}-${{ matrix.beta }}-${{ matrix.variant }}-
+            xcode-cache-deriveddata-${{ runner.os }}-
+          deriveddata-directory: ${{ github.workspace }}/build-Xcode
+          sourcepackages-directory: ${{ github.workspace }}/build-Xcode/SourcePackages
+
+      - name: Set Xcode Version
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Install Homebrew Dependencies
+        run: brew install cmake ninja bartycrouch
+
+      - name: Build Application
+        run: |
+          mkdir -p "${{ github.workspace }}/archives"
+          xcodebuild archive \
+            -archivePath "${{ github.workspace }}/archives/${{ matrix.archive_name }}.xcarchive" \
+            -configuration "${{ matrix.configuration }}" \
+            -scheme "${{ matrix.scheme }}" \
+            ${{ env.XCODE_COMMON_BUILD_ARGS }}
+
+      - name: Package IPA/TIPA
+        run: |
+          mkdir -p "${{ github.workspace }}/products"
+          cp -r "${{ github.workspace }}/archives/${{ matrix.archive_name }}.xcarchive/Products/Applications/DolphiniOS.app" "${{ github.workspace }}/DolphiniOS.app"
+          cd "${{ github.workspace }}"
+          rm -rf Payload
+          mkdir -p Payload
+          mv DolphiniOS.app Payload/DolphiniOS.app
+          zip -r "products/${{ matrix.output_name }}" Payload
+          rm -rf Payload
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.output_name }}
+          path: ${{ github.workspace }}/products/${{ matrix.output_name }}
+          archive: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -106,3 +106,7 @@
 	path = Externals/miniupnpc/miniupnp
 	url = https://github.com/miniupnp/miniupnp.git
 	shallow = true
+[submodule "Externals/StikJIT-iOS/StikJIT"]
+	path = Externals/StikJIT-iOS/StikJIT
+	url = https://github.com/StephenDev0/StikJIT.git
+	shallow = true

--- a/Source/iOS/App/Common/Jit/DDIManager.swift
+++ b/Source/iOS/App/Common/Jit/DDIManager.swift
@@ -1,0 +1,84 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+func appendingStikJITTroubleshootingHint(_ message: String) -> String {
+  guard message.contains("Connection refused") else { return message }
+  return "\(message) Reboot your device, then try again."
+}
+
+@objc class DDIManager: NSObject {
+  @objc static let shared = DDIManager()
+
+  private var ddiDirectory: URL {
+    let libraryFolder = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)[0]
+    return URL(fileURLWithPath: libraryFolder).appendingPathComponent("StikJIT")
+  }
+
+  private var ddiPaths: DDIPaths {
+    DDIPaths.default(in: ddiDirectory)
+  }
+
+  @objc func checkStatus(completion: @escaping (String) -> Void) {
+    guard #available(iOS 17.4, *) else {
+      completion("Unavailable")
+      return
+    }
+
+    completion(ddiPaths.allFilesExist ? "Present" : "Not Present")
+  }
+
+  @objc func deleteCachedDDI() {
+    try? FileManager.default.removeItem(at: ddiDirectory.appendingPathComponent("DDI"))
+  }
+
+  @objc func checkIsMounted(completion: @escaping (Bool, String?) -> Void) {
+    guard #available(iOS 17.4, *) else {
+      completion(false, "Requires iOS 17.4 or later.")
+      return
+    }
+
+    guard let pairingFileURL = StikJITManager.shared.currentPairingFileURL() else {
+      completion(false, "No pairing file imported.")
+      return
+    }
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      do {
+        let mounted = try StikJIT.isDDIMounted(pairingFile: pairingFileURL)
+        DispatchQueue.main.async { completion(mounted, nil) }
+      } catch {
+        DispatchQueue.main.async { completion(false, appendingStikJITTroubleshootingHint(error.localizedDescription)) }
+      }
+    }
+  }
+
+  @objc func mountDDI(progress: @escaping (Double, String) -> Void, completion: @escaping (Bool, String?) -> Void) {
+    guard #available(iOS 17.4, *) else {
+      completion(false, "Requires iOS 17.4 or later.")
+      return
+    }
+
+    guard let pairingFileURL = StikJITManager.shared.currentPairingFileURL() else {
+      completion(false, "No pairing file imported.")
+      return
+    }
+
+    Task {
+      do {
+        let paths = ddiPaths
+        try await StikJIT.downloadDDIIfNeeded(to: paths) { fraction, status in
+          DispatchQueue.main.async { progress(fraction, status) }
+        }
+        DispatchQueue.main.async { progress(1, "Mounting Developer Disk Image...") }
+        try StikJIT.mountDDI(pairingFile: pairingFileURL, paths: paths) { fraction in
+          DispatchQueue.main.async { progress(fraction, "Mounting Developer Disk Image...") }
+        }
+        DispatchQueue.main.async { completion(true, nil) }
+      } catch {
+        DispatchQueue.main.async { completion(false, appendingStikJITTroubleshootingHint(error.localizedDescription)) }
+      }
+    }
+  }
+}

--- a/Source/iOS/App/Common/Jit/JITEnablerExtension/Info.plist
+++ b/Source/iOS/App/Common/Jit/JITEnablerExtension/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>JITEnabler</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>FALSEPREDICATE</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.ar.viewer</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).JITEnablerRequestHandler</string>
+	</dict>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+	</dict>
+</dict>
+</plist>

--- a/Source/iOS/App/Common/Jit/JITEnablerExtension/JITEnablerExtension.entitlements
+++ b/Source/iOS/App/Common/Jit/JITEnablerExtension/JITEnablerExtension.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>get-task-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/iOS/App/Common/Jit/JITEnablerExtension/JITEnablerRequestHandler.swift
+++ b/Source/iOS/App/Common/Jit/JITEnablerExtension/JITEnablerRequestHandler.swift
@@ -1,0 +1,66 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+@objc(StikJITRunnerXPCProtocol)
+protocol StikJITRunnerXPCProtocol {
+  func enableJIT(forParentPID pid: Int32, pairingData: Data, scriptIdentifier: String)
+}
+
+@objc(StikJITHostXPCProtocol)
+protocol StikJITHostXPCProtocol {
+  func jitLog(_ line: String)
+  func jitFinished(_ ok: Bool, error: String?)
+}
+
+private let kListenerEndpointKey = "DOLStikJITListenerEndpoint"
+
+@objc(JITEnablerRequestHandler)
+final class JITEnablerRequestHandler: NSObject, NSExtensionRequestHandling, StikJITRunnerXPCProtocol {
+  private var connection: NSXPCConnection?
+  private var host: StikJITHostXPCProtocol?
+
+  func beginRequest(with context: NSExtensionContext) {
+    NSLog("[JITEnabler] helper beginRequest")
+
+    guard let item = context.inputItems.first as? NSExtensionItem,
+          let endpoint = item.userInfo?[kListenerEndpointKey] as? NSXPCListenerEndpoint else {
+      NSLog("[JITEnabler] missing listener endpoint")
+      context.cancelRequest(withError: NSError(domain: "JITEnablerRequestHandler", code: 1))
+      return
+    }
+
+    let connection = NSXPCConnection(listenerEndpoint: endpoint)
+    connection.exportedInterface = NSXPCInterface(with: StikJITRunnerXPCProtocol.self)
+    connection.exportedObject = self
+    connection.remoteObjectInterface = NSXPCInterface(with: StikJITHostXPCProtocol.self)
+    connection.resume()
+    self.connection = connection
+    self.host = connection.remoteObjectProxyWithErrorHandler { _ in } as? StikJITHostXPCProtocol
+    host?.jitLog("StikJIT runner alive, pid \(getpid())")
+  }
+
+  func enableJIT(forParentPID pid: Int32, pairingData: Data, scriptIdentifier: String) {
+    let host = self.host
+    let script: StikJIT.Script = scriptIdentifier == "universal" ? .universal : .legacy
+    host?.jitLog("enableJIT pid=\(pid) script=\(scriptIdentifier) pairingBytes=\(pairingData.count)")
+
+    Thread.detachNewThread {
+      let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("jitenabler-pairing-\(getpid()).plist")
+      do {
+        try pairingData.write(to: tmp, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        host?.jitLog("wrote \(pairingData.count) pairing bytes to \(tmp.path); attaching to pid \(pid)")
+        try StikJIT.enableJIT(targetPID: pid, pairingFile: tmp, script: script) { line in
+          host?.jitLog(line)
+        }
+        host?.jitFinished(true, error: nil)
+      } catch {
+        host?.jitLog("enableJIT failed: \(String(describing: error))")
+        host?.jitFinished(false, error: error.localizedDescription)
+      }
+    }
+  }
+}

--- a/Source/iOS/App/Common/Jit/JITEnablerExtension/main.m
+++ b/Source/iOS/App/Common/Jit/JITEnablerExtension/main.m
@@ -1,0 +1,27 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#import <Foundation/Foundation.h>
+#import <dlfcn.h>
+#import <objc/runtime.h>
+
+static void DOLStikJITAllowXPCClass(id self, SEL _cmd, id cls, id key, BOOL allowingInvocations) {}
+
+__attribute__((used, visibility("default")))
+int NSExtensionMain(int argc, char* argv[]) {
+    NSLog(@"[JITEnabler] NSExtensionMain entered");
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    Method method = class_getInstanceMethod(
+        NSClassFromString(@"NSXPCDecoder"),
+        @selector(_validateAllowedClass:forKey:allowingInvocations:));
+    if (method) {
+        method_setImplementation(method, (IMP)DOLStikJITAllowXPCClass);
+    }
+#pragma clang diagnostic pop
+
+    int (*originalNSExtensionMain)(int, char**) =
+        (int (*)(int, char**))dlsym(RTLD_NEXT, "NSExtensionMain");
+    return originalNSExtensionMain(argc, argv);
+}

--- a/Source/iOS/App/Common/Jit/JitManager+StikDebugURLScheme.swift
+++ b/Source/iOS/App/Common/Jit/JitManager+StikDebugURLScheme.swift
@@ -28,7 +28,7 @@ extension JitManager {
     }
 
     var components = URLComponents()
-    components.scheme = "stikjit"
+    components.scheme = "stikdebug"
     components.host = "enable-jit"
     components.queryItems = queryItems
 

--- a/Source/iOS/App/Common/Jit/JitManager+StikDebugURLScheme.swift
+++ b/Source/iOS/App/Common/Jit/JitManager+StikDebugURLScheme.swift
@@ -1,0 +1,43 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+import UIKit
+
+extension JitManager {
+  @objc func acquireJitByStikDebugURLScheme() {
+    guard #available(iOS 17.4, *) else {
+      return
+    }
+
+    guard !StikJITManager.shared.selfEnableJitEnabled else {
+      return
+    }
+
+    guard let bundleID = Bundle.main.bundleIdentifier else {
+      return
+    }
+
+    var queryItems = [
+      URLQueryItem(name: "bundle-id", value: bundleID),
+      URLQueryItem(name: "pid", value: String(getpid())),
+    ]
+
+    if self.deviceHasTxm {
+      queryItems.append(URLQueryItem(name: "script-name", value: "legacy.js"))
+    }
+
+    var components = URLComponents()
+    components.scheme = "stikjit"
+    components.host = "enable-jit"
+    components.queryItems = queryItems
+
+    guard let url = components.url else {
+      return
+    }
+
+    DispatchQueue.main.async {
+      UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+  }
+}

--- a/Source/iOS/App/Common/Jit/JitManager+StikJIT.swift
+++ b/Source/iOS/App/Common/Jit/JitManager+StikJIT.swift
@@ -1,0 +1,94 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+private let kRequestTimeout: TimeInterval = 20
+private var isAttemptingStikJIT = false
+private var currentAttemptID = 0
+private var activeLauncher: StikJITExtensionLauncher?
+private var activeHost: StikJITHostBridge?
+
+private class StikJITHostBridge: NSObject, StikJITHostXPCProtocol {
+  var onLog: ((String) -> Void)?
+  var onFinished: ((Bool, String?) -> Void)?
+
+  func jitLog(_ line: String) {
+    onLog?(line)
+  }
+
+  func jitFinished(_ ok: Bool, error: String?) {
+    onFinished?(ok, error)
+  }
+}
+
+extension JitManager {
+  @objc func acquireJitByStikJIT() {
+    guard #available(iOS 17.4, *) else {
+      return
+    }
+
+    guard StikJITManager.shared.selfEnableJitEnabled,
+          let pairingFileURL = StikJITManager.shared.currentPairingFileURL(),
+          !isAttemptingStikJIT else {
+      return
+    }
+
+    guard let pairingData = try? Data(contentsOf: pairingFileURL) else {
+      self.acquisitionError = "StikJIT failed to enable JIT: could not read the pairing file."
+      return
+    }
+
+    isAttemptingStikJIT = true
+    currentAttemptID += 1
+    let attemptID = currentAttemptID
+    let targetPID = Int32(getpid())
+
+    let host = StikJITHostBridge()
+    let launcher = StikJITExtensionLauncher(host: host)
+    activeHost = host
+    activeLauncher = launcher
+
+    func finish(ok: Bool, message: String?) {
+      guard attemptID == currentAttemptID else { return }
+      isAttemptingStikJIT = false
+      activeLauncher?.invalidate()
+      activeLauncher = nil
+      activeHost = nil
+
+      if !ok {
+        let hintedMessage = appendingStikJITTroubleshootingHint(message ?? "Unknown error")
+        DispatchQueue.main.async { [weak self] in
+          self?.acquisitionError = "StikJIT failed to enable JIT: \(hintedMessage)"
+        }
+      }
+    }
+
+    host.onLog = { line in
+      NSLog("[StikJIT runner] %@", line)
+    }
+    host.onFinished = { ok, message in
+      finish(ok: ok, message: message)
+    }
+
+    launcher.launch { _, runner, error in
+      if let error {
+        finish(ok: false, message: error.localizedDescription)
+        return
+      }
+
+      guard let runner else {
+        finish(ok: false, message: "Could not create the StikJIT runner proxy.")
+        return
+      }
+
+      NSLog("[StikJIT] runner connected; attaching to pid %d", targetPID)
+      runner.enableJIT(forParentPID: targetPID, pairingData: pairingData, scriptIdentifier: "legacy")
+    }
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + kRequestTimeout) {
+      guard attemptID == currentAttemptID, isAttemptingStikJIT else { return }
+      finish(ok: false, message: "the JITEnabler extension did not respond in time. Make sure you are connected to Wi-Fi/Airplane Mode and LocalDevVPN, the DDI is mounted, and your pairing file is valid.")
+    }
+  }
+}

--- a/Source/iOS/App/Common/Jit/JitManager.m
+++ b/Source/iOS/App/Common/Jit/JitManager.m
@@ -72,7 +72,7 @@ typedef NS_ENUM(NSInteger, DOLJitType) {
     self.acquiredJit = [self checkIfProcessIsDebugged];
     
     if (self.deviceHasTxm && self.acquiredJit) {
-      self.acquisitionError = @"A debugger is attached. However, if the debugger is not StikDebug, DolphiniOS will crash when emulation starts.";
+      self.acquisitionError = @"A debugger is attached. However, if the debugger is not StikDebug/StikJIT, DolphiniOS will crash when emulation starts.";
     }
   } else if (_jitType == DOLJitTypeUnrestricted) {
     self.acquiredJit = true;

--- a/Source/iOS/App/Common/Jit/StikJITExtensionLauncher.h
+++ b/Source/iOS/App/Common/Jit/StikJITExtensionLauncher.h
@@ -1,0 +1,31 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol StikJITRunnerXPCProtocol
+- (void)enableJITForParentPID:(int32_t)pid
+                  pairingData:(NSData*)pairingData
+             scriptIdentifier:(NSString*)scriptIdentifier;
+@end
+
+@protocol StikJITHostXPCProtocol
+- (void)jitLog:(NSString*)line;
+- (void)jitFinished:(BOOL)ok error:(nullable NSString*)error;
+@end
+
+@interface StikJITExtensionLauncher : NSObject
+
+- (instancetype)initWithHost:(id<StikJITHostXPCProtocol>)host;
+
+- (void)launchWithCompletion:(void (^)(int32_t pid,
+                                       id<StikJITRunnerXPCProtocol> _Nullable runner,
+                                       NSError* _Nullable error))completion;
+
+- (void)invalidate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/iOS/App/Common/Jit/StikJITExtensionLauncher.m
+++ b/Source/iOS/App/Common/Jit/StikJITExtensionLauncher.m
@@ -1,0 +1,164 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#import "StikJITExtensionLauncher.h"
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+@interface NSExtension : NSObject
+- (nullable NSUUID*)beginRequestWithInputItems:(NSArray<NSExtensionItem*>*)items;
+- (void)setRequestInterruptionBlock:(void (^)(NSUUID* requestIdentifier))block;
+- (pid_t)pidForRequestIdentifier:(NSUUID*)requestIdentifier;
+- (void)_kill:(int)signal;
+@end
+
+static NSString* const kStikJITListenerEndpointKey = @"DOLStikJITListenerEndpoint";
+
+@interface StikJITListenerDelegate : NSObject <NSXPCListenerDelegate>
+@property(copy, nullable) void (^onConnection)(NSXPCConnection* c);
+@end
+
+@implementation StikJITListenerDelegate
+- (BOOL)listener:(NSXPCListener*)listener shouldAcceptNewConnection:(NSXPCConnection*)c {
+    if (self.onConnection) self.onConnection(c);
+    return YES;
+}
+@end
+
+@implementation StikJITExtensionLauncher {
+    __weak id<StikJITHostXPCProtocol> _host;
+    NSXPCListener* _listener;
+    StikJITListenerDelegate* _delegate;
+    NSXPCConnection* _connection;
+    NSExtension* _extension;
+    NSUUID* _requestId;
+    int32_t _childPID;
+    BOOL _completed;
+}
+
+- (instancetype)initWithHost:(id<StikJITHostXPCProtocol>)host {
+    if ((self = [super init])) { _host = host; }
+    return self;
+}
+
+- (nullable NSString*)childBundleIdentifier {
+    NSURL* plugins = [NSBundle mainBundle].builtInPlugInsURL;
+    if (!plugins) return nil;
+    NSArray<NSURL*>* items = [[NSFileManager defaultManager]
+        contentsOfDirectoryAtURL:plugins
+      includingPropertiesForKeys:nil
+                         options:NSDirectoryEnumerationSkipsHiddenFiles
+                           error:nil];
+    for (NSURL* url in items) {
+        if ([[url pathExtension] isEqualToString:@"appex"]) {
+            NSBundle* b = [NSBundle bundleWithURL:url];
+            if (b.bundleIdentifier) return b.bundleIdentifier;
+        }
+    }
+    return nil;
+}
+
+- (nullable NSExtension*)createExtension:(NSString*)identifier error:(NSError**)error {
+    Class cls = NSClassFromString(@"NSExtension");
+    SEL sel = NSSelectorFromString(@"extensionWithIdentifier:excludingDisabledExtensions:error:");
+    if (!cls || !class_getClassMethod(cls, sel)) return nil;
+    typedef id (*Fn)(id, SEL, NSString*, BOOL, NSError**);
+    return ((Fn)objc_msgSend)(cls, sel, identifier, NO, error);
+}
+
+- (void)launchWithCompletion:(void (^)(int32_t, id<StikJITRunnerXPCProtocol> _Nullable, NSError* _Nullable))completion {
+    void (^complete)(int32_t, id, NSError*) = ^(int32_t pid, id runner, NSError* err) {
+        if (self->_completed) return;
+        self->_completed = YES;
+        completion(pid, runner, err);
+    };
+
+    _delegate = [StikJITListenerDelegate new];
+    _listener = [NSXPCListener anonymousListener];
+    __weak typeof(self) weakSelf = self;
+    _delegate.onConnection = ^(NSXPCConnection* c) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf || strongSelf->_connection) { [c invalidate]; return; }
+        strongSelf->_connection = c;
+        c.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(StikJITHostXPCProtocol)];
+        c.exportedObject = strongSelf->_host;
+        c.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol:@protocol(StikJITRunnerXPCProtocol)];
+        [c resume];
+        id<StikJITRunnerXPCProtocol> runner = [c remoteObjectProxyWithErrorHandler:^(NSError* e) {}];
+        complete(strongSelf->_childPID, runner, nil);
+    };
+    _listener.delegate = _delegate;
+    [_listener resume];
+
+    NSString* identifier = [self childBundleIdentifier];
+    if (!identifier) {
+        NSLog(@"[StikJITLauncher] no .appex found in %@", [NSBundle mainBundle].builtInPlugInsURL);
+        complete(-1, nil, [NSError errorWithDomain:@"StikJITLauncher" code:1
+                                          userInfo:@{NSLocalizedDescriptionKey: @"StikJIT runner .appex not found"}]);
+        return;
+    }
+    NSLog(@"[StikJITLauncher] launching runner extension %@", identifier);
+
+    NSError* err = nil;
+    _extension = [self createExtension:identifier error:&err];
+    if (!_extension) {
+        NSString* reason = err.localizedDescription
+            ? [NSString stringWithFormat:@"NSExtension creation failed: %@", err.localizedDescription]
+            : @"NSExtension creation failed";
+        NSLog(@"[StikJITLauncher] %@ (underlying: %@)", reason, err);
+        complete(-1, nil, err ?: [NSError errorWithDomain:@"StikJITLauncher" code:2
+                                                 userInfo:@{NSLocalizedDescriptionKey: reason}]);
+        return;
+    }
+
+    if ([_extension respondsToSelector:@selector(setRequestInterruptionBlock:)]) {
+        [_extension setRequestInterruptionBlock:^(NSUUID* req) {
+            NSLog(@"[StikJITLauncher] runner interrupted before bootstrap (request %@)", req);
+            complete(-1, nil, [NSError errorWithDomain:@"StikJITLauncher" code:3
+                                              userInfo:@{NSLocalizedDescriptionKey: @"runner interrupted before bootstrap"}]);
+        }];
+    }
+
+    NSExtensionItem* input = [NSExtensionItem new];
+    input.userInfo = @{ kStikJITListenerEndpointKey: _listener.endpoint };
+
+    NSError* reqErr = nil;
+    SEL beginSel = NSSelectorFromString(@"beginExtensionRequestWithInputItems:error:");
+    if ([_extension respondsToSelector:beginSel]) {
+        typedef id (*Fn)(id, SEL, NSArray*, NSError**);
+        id req = ((Fn)objc_msgSend)(_extension, beginSel, @[input], &reqErr);
+        _requestId = [req isKindOfClass:[NSUUID class]] ? req : nil;
+    } else {
+        _requestId = [_extension beginRequestWithInputItems:@[input]];
+    }
+    if (!_requestId) {
+        NSString* reason = reqErr.localizedDescription
+            ? [NSString stringWithFormat:@"begin extension request failed: %@", reqErr.localizedDescription]
+            : @"begin extension request failed";
+        NSLog(@"[StikJITLauncher] %@ (underlying: %@)", reason, reqErr);
+        complete(-1, nil, [NSError errorWithDomain:@"StikJITLauncher" code:4
+                                          userInfo:@{NSLocalizedDescriptionKey: reason}]);
+        return;
+    }
+
+    if ([_extension respondsToSelector:@selector(pidForRequestIdentifier:)]) {
+        _childPID = [_extension pidForRequestIdentifier:_requestId];
+    }
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 12 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        complete(-1, nil, [NSError errorWithDomain:@"StikJITLauncher" code:5
+                                          userInfo:@{NSLocalizedDescriptionKey: @"timed out waiting for runner"}]);
+    });
+}
+
+- (void)invalidate {
+    if (_connection) { [_connection invalidate]; _connection = nil; }
+    if (_extension) {
+        if (_requestId && [_extension respondsToSelector:@selector(_kill:)]) [_extension _kill:9];
+        _extension = nil;
+    }
+    if (_listener) { _listener.delegate = nil; [_listener invalidate]; _listener = nil; }
+    _delegate = nil;
+}
+
+@end

--- a/Source/iOS/App/Common/Jit/StikJITManager.swift
+++ b/Source/iOS/App/Common/Jit/StikJITManager.swift
@@ -1,0 +1,49 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+private let kSelfEnableJitDefaultsKey = "stikjit_self_enable_jit"
+private let kPairingFileName = "pairingFile.plist"
+private let kStikJITFolderName = "StikJIT"
+
+@objc class StikJITManager: NSObject {
+  @objc static let shared = StikJITManager()
+
+  private let pairingFileURL: URL
+
+  override init() {
+    let userFolder = UserFolderUtil.getUserFolder()
+    let stikJITFolder = URL(fileURLWithPath: userFolder).appendingPathComponent(kStikJITFolderName)
+
+    try? FileManager.default.createDirectory(at: stikJITFolder, withIntermediateDirectories: true)
+    self.pairingFileURL = stikJITFolder.appendingPathComponent(kPairingFileName)
+
+    super.init()
+  }
+
+  @objc var selfEnableJitEnabled: Bool {
+    get { UserDefaults.standard.bool(forKey: kSelfEnableJitDefaultsKey) }
+    set { UserDefaults.standard.set(newValue, forKey: kSelfEnableJitDefaultsKey) }
+  }
+
+  @objc var hasPairingFile: Bool {
+    FileManager.default.fileExists(atPath: pairingFileURL.path)
+  }
+
+  @objc var pairingFileDisplayName: String {
+    hasPairingFile ? pairingFileURL.lastPathComponent : "Not Imported"
+  }
+
+  func currentPairingFileURL() -> URL? {
+    hasPairingFile ? pairingFileURL : nil
+  }
+
+  @objc func importPairingFile(_ sourceURL: URL) throws {
+    if FileManager.default.fileExists(atPath: pairingFileURL.path) {
+      try FileManager.default.removeItem(at: pairingFileURL)
+    }
+
+    try FileManager.default.copyItem(at: sourceURL, to: pairingFileURL)
+  }
+}

--- a/Source/iOS/App/Common/Swift/BridgingHeader.h
+++ b/Source/iOS/App/Common/Swift/BridgingHeader.h
@@ -11,6 +11,7 @@
 #import "JitManager.h"
 #import "JitManager+AltServer.h"
 #import "JitManager+JitStreamer.h"
+#import "StikJITExtensionLauncher.h"
 #import "JitManager+PTrace.h"
 #import "LegacyInputConfigMigrationService.h"
 #import "MainSceneCoordinator.h"

--- a/Source/iOS/App/Common/UI/Emulation/JitWait/JitWaitViewController.swift
+++ b/Source/iOS/App/Common/UI/Emulation/JitWait/JitWaitViewController.swift
@@ -5,15 +5,21 @@ import UIKit
 
 class JitWaitViewController: UIViewController {
   @objc weak var delegate: JitWaitViewControllerDelegate?
-  
+  @IBOutlet var stikJITButton: UIButton!
+
   var timer: Timer?
   var isShowingError: Bool = false
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
-    
+
     self.timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(checkJit), userInfo: nil, repeats: true)
-    
+
+    if #available(iOS 17.4, *) {
+      let stikJITReady = StikJITManager.shared.selfEnableJitEnabled && StikJITManager.shared.hasPairingFile
+      stikJITButton.isHidden = !stikJITReady
+    }
+
     JitManager.shared().acquireJitByAltServer()
     JitManager.shared().acquireJitByJitStreamer()
   }
@@ -57,6 +63,63 @@ class JitWaitViewController: UIViewController {
     }
   }
   
+  @IBAction func stikJITPressed(_ sender: Any) {
+    let alertController = UIAlertController(
+      title: "Before Continuing",
+      message: "If you have access to a nearby Wi-Fi network, connect to it now, connect to LocalDevVPN, then return here and continue. If you don't have access to a Wi-Fi network, make sure Cellular Data is enabled, connect to LocalDevVPN, then enable Airplane Mode, return here, and continue.",
+      preferredStyle: .alert)
+
+    alertController.addAction(UIAlertAction(title: DOLCoreLocalizedString("Cancel"), style: .cancel, handler: nil))
+    alertController.addAction(UIAlertAction(title: "Continue", style: .default, handler: { [weak self] _ in
+      self?.startStikJITWithDDICheck()
+    }))
+
+    self.present(alertController, animated: true, completion: nil)
+  }
+
+  private func startStikJITWithDDICheck() {
+    guard #available(iOS 17.4, *) else {
+      JitManager.shared().acquireJitByStikJIT()
+      return
+    }
+
+    self.stikJITButton.isEnabled = false
+    self.stikJITButton.setTitle("Checking Developer Disk Image...", for: .normal)
+
+    DDIManager.shared.checkIsMounted { [weak self] mounted, _ in
+      guard let self = self else { return }
+
+      if mounted {
+        self.finishDDIStepAndAcquireJit()
+        return
+      }
+
+      DDIManager.shared.mountDDI(progress: { [weak self] fraction, status in
+        self?.stikJITButton.setTitle("\(status) (\(Int(fraction * 100))%)", for: .normal)
+      }, completion: { [weak self] success, error in
+        guard let self = self else { return }
+
+        if success {
+          self.finishDDIStepAndAcquireJit()
+          return
+        }
+
+        self.stikJITButton.isEnabled = true
+        self.stikJITButton.setTitle("Enable JIT with StikJIT", for: .normal)
+
+        let alertController = UIAlertController(title: DOLCoreLocalizedString("Error"), message: "Failed to mount Developer Disk Image: \(error ?? "Unknown error")", preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: DOLCoreLocalizedString("OK"), style: .default, handler: nil))
+        self.present(alertController, animated: true, completion: nil)
+      })
+    }
+  }
+
+  private func finishDDIStepAndAcquireJit() {
+    self.stikJITButton.isEnabled = true
+    self.stikJITButton.setTitle("Enable JIT with StikJIT", for: .normal)
+    JitManager.shared().acquireJitByStikJIT()
+  }
+
   @IBAction func helpPressed(_ sender: Any) {
     let url = URL.init(string: "https://dolphinios.oatmealdome.me/jit-help")
     UIApplication.shared.open(url!, options: [:], completionHandler: nil)

--- a/Source/iOS/App/Common/UI/Emulation/JitWait/JitWaitViewController.swift
+++ b/Source/iOS/App/Common/UI/Emulation/JitWait/JitWaitViewController.swift
@@ -22,6 +22,7 @@ class JitWaitViewController: UIViewController {
 
     JitManager.shared().acquireJitByAltServer()
     JitManager.shared().acquireJitByJitStreamer()
+    JitManager.shared().acquireJitByStikDebugURLScheme()
   }
   
   override func viewWillAppear(_ animated: Bool) {

--- a/Source/iOS/App/Common/UI/Settings/About/AboutViewController.m
+++ b/Source/iOS/App/Common/UI/Settings/About/AboutViewController.m
@@ -25,4 +25,9 @@
   [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 }
 
+- (IBAction)stikJITCreditPressed:(id)sender {
+  NSURL* url = [NSURL URLWithString:@"https://github.com/StephenDev0/StikJIT"];
+  [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+}
+
 @end

--- a/Source/iOS/App/Common/UI/Settings/Debug/DebugRootViewController.h
+++ b/Source/iOS/App/Common/UI/Settings/Debug/DebugRootViewController.h
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet DOLSwitch* fastmemSwitch;
 @property (weak, nonatomic) IBOutlet DOLSwitch* syncOnIdleSkipSwitch;
 @property (weak, nonatomic) IBOutlet DOLSwitch* mfiSwitch;
+@property (weak, nonatomic) IBOutlet DOLSwitch* selfEnableJitSwitch;
 @property (weak, nonatomic) IBOutlet UILabel* userFolderPathLabel;
 @property (weak, nonatomic) IBOutlet UILabel* jitStatusLabel;
 @property (weak, nonatomic) IBOutlet UILabel* jitErrorLabel;
 @property (weak, nonatomic) IBOutlet UILabel* fastmemStatusLabel;
 @property (weak, nonatomic) IBOutlet UILabel* launchTimesLabel;
+@property (weak, nonatomic) IBOutlet UILabel* importPairingFileStatusLabel;
+@property (weak, nonatomic) IBOutlet UILabel* ddiMounterStatusLabel;
 
 @end
 

--- a/Source/iOS/App/Common/UI/Settings/Debug/DebugRootViewController.mm
+++ b/Source/iOS/App/Common/UI/Settings/Debug/DebugRootViewController.mm
@@ -3,6 +3,8 @@
 
 #import "DebugRootViewController.h"
 
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
 #import "Core/Config/MainSettings.h"
 
 #import "Swift.h"
@@ -11,7 +13,7 @@
 #import "JitManager.h"
 #import "VirtualMFiControllerManager.h"
 
-@interface DebugRootViewController ()
+@interface DebugRootViewController () <UIDocumentPickerDelegate>
 
 @end
 
@@ -29,7 +31,20 @@
   
   self.mfiSwitch.on = [VirtualMFiControllerManager shared].shouldConnectController;
   [self.mfiSwitch addValueChangedTarget:self action:@selector(mfiChanged)];
-  
+
+  self.selfEnableJitSwitch.on = [StikJITManager shared].selfEnableJitEnabled;
+  [self.selfEnableJitSwitch addValueChangedTarget:self action:@selector(selfEnableJitChanged)];
+
+  if (@available(iOS 17.4, *)) {
+  } else {
+    self.selfEnableJitSwitch.on = false;
+    self.selfEnableJitSwitch.enabled = false;
+  }
+
+  self.importPairingFileStatusLabel.text = [StikJITManager shared].pairingFileDisplayName;
+
+  [self refreshDDIStatus];
+
   self.userFolderPathLabel.text = [UserFolderUtil getUserFolder];
   
   if ([JitManager shared].acquiredJit)
@@ -80,44 +95,89 @@
   [VirtualMFiControllerManager shared].shouldConnectController = self.mfiSwitch.on;
 }
 
-#ifndef DEBUG
+- (void)selfEnableJitChanged {
+  [StikJITManager shared].selfEnableJitEnabled = self.selfEnableJitSwitch.on;
+
+  [self.tableView beginUpdates];
+  [self.tableView endUpdates];
+
+  if (self.selfEnableJitSwitch.on) {
+    [self refreshDDIStatus];
+  }
+}
+
+- (void)refreshDDIStatus {
+  self.ddiMounterStatusLabel.text = @"Checking...";
+
+  __weak DebugRootViewController* weakSelf = self;
+  [[DDIManager shared] checkStatusWithCompletion:^(NSString* status) {
+    DebugRootViewController* strongSelf = weakSelf;
+    if (strongSelf == nil) {
+      return;
+    }
+
+    strongSelf.ddiMounterStatusLabel.text = status;
+  }];
+}
+
+- (void)confirmDeleteDDI {
+  UIAlertController* confirmAlert = [UIAlertController alertControllerWithTitle:@"Delete Developer Disk Image" message:@"This will delete the cached Developer Disk Image. It will be downloaded and mounted again the next time you enable JIT with StikJIT." preferredStyle:UIAlertControllerStyleAlert];
+
+  [confirmAlert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+  __weak DebugRootViewController* weakSelf = self;
+  [confirmAlert addAction:[UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction* action) {
+    [[DDIManager shared] deleteCachedDDI];
+    [weakSelf refreshDDIStatus];
+  }]];
+
+  [self presentViewController:confirmAlert animated:true completion:nil];
+}
 
 - (CGFloat)tableView:(UITableView*)tableView heightForHeaderInSection:(NSInteger)section {
+#ifndef DEBUG
   if (section == 1 || section == 2) {
     return CGFLOAT_MIN;
   }
-  
+#endif
+
   return UITableViewAutomaticDimension;
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
+#ifndef DEBUG
   if (section == 1 || section == 2) {
     return CGFLOAT_MIN;
   }
-  
+#endif
+
   return UITableViewAutomaticDimension;
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
+  if (indexPath.section == 3 && (indexPath.row == 4 || indexPath.row == 5) && !self.selfEnableJitSwitch.on) {
+    return CGFLOAT_MIN;
+  }
+
+#ifndef DEBUG
   if (indexPath.section == 1 || indexPath.section == 2) {
     return CGFLOAT_MIN;
   }
-  
+#endif
+
   return UITableViewAutomaticDimension;
 }
-
-#endif
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
   if (indexPath.section == 2 && indexPath.row == 0) { // Reset Launch Times
     [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:@"launch_times"];
-    
+
     UIAlertController* launchAlert = [UIAlertController alertControllerWithTitle:@"Reset" message:@"launch_times was reset to 0." preferredStyle:UIAlertControllerStyleAlert];
-    
+
     [launchAlert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action) {
       //
     }]];
-    
+
     [self presentViewController:launchAlert animated:true completion:nil];
   } else if (indexPath.section == 2 && indexPath.row == 1) { // Force Start Motion
 #if TARGET_OS_IOS
@@ -125,9 +185,47 @@
     [sharedMotion setPort:4];
     [sharedMotion setMotionEnabled:true];
 #endif
+  } else if (indexPath.section == 3 && indexPath.row == 4) {
+    NSArray<UTType*>* contentTypes = @[[UTType typeWithIdentifier:@"public.data"]];
+
+    UIDocumentPickerViewController* picker = [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:contentTypes];
+    picker.delegate = self;
+
+    [self presentViewController:picker animated:true completion:nil];
+  } else if (indexPath.section == 3 && indexPath.row == 5) {
+    [self confirmDeleteDDI];
   }
-  
+
   [self.tableView deselectRowAtIndexPath:indexPath animated:true];
+}
+
+- (void)documentPicker:(UIDocumentPickerViewController*)controller didPickDocumentsAtURLs:(NSArray<NSURL*>*)urls {
+  NSURL* url = urls.firstObject;
+
+  if (url == nil) {
+    return;
+  }
+
+  if (![url startAccessingSecurityScopedResource]) {
+    return;
+  }
+
+  NSError* error = nil;
+  [[StikJITManager shared] importPairingFile:url error:&error];
+
+  [url stopAccessingSecurityScopedResource];
+
+  if (error != nil) {
+    UIAlertController* errorAlert = [UIAlertController alertControllerWithTitle:@"Error" message:[NSString stringWithFormat:@"Failed to import pairing file: %@", [error localizedDescription]] preferredStyle:UIAlertControllerStyleAlert];
+
+    [errorAlert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+
+    [self presentViewController:errorAlert animated:true completion:nil];
+
+    return;
+  }
+
+  self.importPairingFileStatusLabel.text = [StikJITManager shared].pairingFileDisplayName;
 }
 
 @end

--- a/Source/iOS/App/DolphiniOS.xcodeproj/project.pbxproj
+++ b/Source/iOS/App/DolphiniOS.xcodeproj/project.pbxproj
@@ -7,6 +7,29 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0ABB5E4CCEEEDBCD2D8D2B75 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E3C7032E870DD08E6F64 /* main.m */; };
+		0C255450097EA1AC3768A98A /* ScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE33DEC1ED32EE76E1C6C20 /* ScriptRunner.swift */; };
+		0C9F05BE6CF6E36FC6552B15 /* ScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE33DEC1ED32EE76E1C6C20 /* ScriptRunner.swift */; };
+		12B74E80A6A36926DF9A8432 /* StikJITError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F845EE5887C3F5B62139E67F /* StikJITError.swift */; };
+		233A0F9C37C9B95888B38707 /* BundledScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA04FB6122848250DDBCC450 /* BundledScript.swift */; };
+		23C9C364A79572842B78A3B6 /* ProcessInfo+TXM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF5095623B61790D4E4F0B9 /* ProcessInfo+TXM.swift */; };
+		26D300A3AC24D2577DDEF559 /* DDIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB5F8BF832C1EF46796F3C6 /* DDIManager.swift */; };
+		402AB7B55CD933E56F5A1B46 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F33FAE5304A06A9D33FB135F /* Foundation.framework */; };
+		444C3F0FCA4C026057B1457F /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05416988C370B963F5653000 /* Security.framework */; };
+		4ECD0F45FAB10DEF2C31334D /* DDISession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D2D2FDA0650F46CC4503C2 /* DDISession.swift */; };
+		4FFC06733A954119961CC7FD /* JITEnablerRequestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF374E5D4F577E8D1B49431 /* JITEnablerRequestHandler.swift */; };
+		57E174338760848870627C22 /* ProcessInfo+TXM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF5095623B61790D4E4F0B9 /* ProcessInfo+TXM.swift */; };
+		5A606D32147443DBAD1A5DD1 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E263662986E8C62858AA75 /* SystemConfiguration.framework */; };
+		5E4809C1A0479998B52B9CAD /* IdeviceFFI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF87CC10F11FDB6F3E0941F4 /* IdeviceFFI.swift */; };
+		6189536A53E6991E45FA74B6 /* StikJIT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D913F3F6511ACA28A99B200 /* StikJIT.swift */; };
+		620249E7FE8CEBC155116D2A /* JitManager+StikJIT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3770D9ACA7BC46B9D2C089DF /* JitManager+StikJIT.swift */; };
+		79586B1E0A77025C9FD40B41 /* BundledScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA04FB6122848250DDBCC450 /* BundledScript.swift */; };
+		8523DE84AB3C6066401C2459 /* JITSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911500DD0CC16F1FAA949A37 /* JITSession.swift */; };
+		85A4831D8CFD03DCC3FD8A02 /* JITEnabler.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E3B76F3465C2C643D991679A /* JITEnabler.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		89528D612625954D14BAA2D8 /* IdeviceFFI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF87CC10F11FDB6F3E0941F4 /* IdeviceFFI.swift */; };
+		911F905600B448977639A62C /* DeveloperDiskImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36A512394FA665642AF6E8C /* DeveloperDiskImageService.swift */; };
+		AC6756A358C337596B4037D9 /* StikJITError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F845EE5887C3F5B62139E67F /* StikJITError.swift */; };
+		ACA1679CFAB09674DB8E06C8 /* StikJIT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D913F3F6511ACA28A99B200 /* StikJIT.swift */; };
 		B900A7A127F255EF000361DD /* libdolphin.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = B9476B2427F23FFE009C0A4B /* libdolphin.dylib */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B900A7A727F26F61000361DD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900A7A627F26F61000361DD /* AppDelegate.swift */; };
 		B900A7AE27F27F36000361DD /* DolphinCoreService.mm in Sources */ = {isa = PBXBuildFile; fileRef = B900A7AD27F27F36000361DD /* DolphinCoreService.mm */; };
@@ -196,9 +219,26 @@
 		B9FCB7E12898D1E80020E233 /* SwiftLocalizationUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FCB7E02898D1E80020E233 /* SwiftLocalizationUtil.swift */; };
 		B9FCB7E42898F4D60020E233 /* JitManager+JitStreamer.m in Sources */ = {isa = PBXBuildFile; fileRef = B9FCB7E32898F4D60020E233 /* JitManager+JitStreamer.m */; };
 		B9FCB7E62898FAC10020E233 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9FCB7E52898FAC10020E233 /* GameController.framework */; };
+		BC57620FAAF42BE6FD2B5B31 /* DDISession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D2D2FDA0650F46CC4503C2 /* DDISession.swift */; };
+		C9380003D02781F71A5505E4 /* universal.js in Resources */ = {isa = PBXBuildFile; fileRef = 6FDE11B38032F76E7F9EC446 /* universal.js */; };
+		CAF13182D2D61F3FBA8596EA /* DeveloperDiskImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36A512394FA665642AF6E8C /* DeveloperDiskImageService.swift */; };
+		D16E73DFF7987A6CDB79AD0E /* StikJITManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDCDA09107E3E4AD91EB106 /* StikJITManager.swift */; };
+		DA61591F4210B0651CFF70BB /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90B836CEF66DD389BA7DFC36 /* JavaScriptCore.framework */; };
+		DE73032B38DFD8649A943D99 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A46CB993191C5AA22E27A3D /* CFNetwork.framework */; };
+		E0330A5A9DC372F70C6DA286 /* StikJITExtensionLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A8952C7410ECC3E945A54E /* StikJITExtensionLauncher.m */; };
+		E549D0ACB0DBF2590C7C33AC /* JITSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911500DD0CC16F1FAA949A37 /* JITSession.swift */; };
+		EF99EC6AA3A6981EE8B76B5A /* legacy.js in Resources */ = {isa = PBXBuildFile; fileRef = 75DC8DD2585483DA18E77900 /* legacy.js */; };
+		FD05A3D9A1809002080AB853 /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C69D8DA358D57C72EE142FB /* Network.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1DF2F7B6A3112E50F02FB48D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B9DC3DEE27EFBD2C0084DAA4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5EC4BDFA0AA54C352390B6AE;
+			remoteInfo = JITEnabler;
+		};
 		B96C9A532A46C1CE002B5ECF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B9DC3DEE27EFBD2C0084DAA4 /* Project object */;
@@ -220,9 +260,38 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F9FD173AA3C68BC3E49F3F0B /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				85A4831D8CFD03DCC3FD8A02 /* JITEnabler.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		05416988C370B963F5653000 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		0A46CB993191C5AA22E27A3D /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		2032526AC3E708754CF79AD1 /* libidevice_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libidevice_ffi.a; path = "../../../Externals/StikJIT-iOS/StikJIT/idevice/libidevice_ffi.a"; sourceTree = SOURCE_ROOT; };
+		3770D9ACA7BC46B9D2C089DF /* JitManager+StikJIT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JitManager+StikJIT.swift"; sourceTree = "<group>"; };
+		4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = JITEnablerExtension.xcconfig; sourceTree = "<group>"; };
+		5BB5F8BF832C1EF46796F3C6 /* DDIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DDIManager.swift; sourceTree = "<group>"; };
+		63E263662986E8C62858AA75 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		6BF374E5D4F577E8D1B49431 /* JITEnablerRequestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JITEnablerRequestHandler.swift; sourceTree = "<group>"; };
+		6FDE11B38032F76E7F9EC446 /* universal.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = universal.js; path = "../../../Externals/StikJIT-iOS/StikJIT/Resources/universal.js"; sourceTree = SOURCE_ROOT; };
+		75DC8DD2585483DA18E77900 /* legacy.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = legacy.js; path = "../../../Externals/StikJIT-iOS/StikJIT/Resources/legacy.js"; sourceTree = SOURCE_ROOT; };
+		7C83E3C7032E870DD08E6F64 /* main.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		7D913F3F6511ACA28A99B200 /* StikJIT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StikJIT.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/StikJIT.swift"; sourceTree = SOURCE_ROOT; };
+		8C69D8DA358D57C72EE142FB /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
+		90B836CEF66DD389BA7DFC36 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		911500DD0CC16F1FAA949A37 /* JITSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JITSession.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/JITSession.swift"; sourceTree = SOURCE_ROOT; };
+		9BF5095623B61790D4E4F0B9 /* ProcessInfo+TXM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProcessInfo+TXM.swift"; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/ProcessInfo+TXM.swift"; sourceTree = SOURCE_ROOT; };
+		A36A512394FA665642AF6E8C /* DeveloperDiskImageService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeveloperDiskImageService.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/DeveloperDiskImageService.swift"; sourceTree = SOURCE_ROOT; };
+		ABE33DEC1ED32EE76E1C6C20 /* ScriptRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScriptRunner.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/ScriptRunner.swift"; sourceTree = SOURCE_ROOT; };
 		B900A7A227F25718000361DD /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		B900A7A627F26F61000361DD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B900A7AC27F27F36000361DD /* DolphinCoreService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DolphinCoreService.h; sourceTree = "<group>"; };
@@ -577,9 +646,31 @@
 		B9FF01E72977DCBE00B49B00 /* TrollStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TrollStore.xcconfig; sourceTree = "<group>"; };
 		B9FF01E82977DCF700B49B00 /* Release (TrollStore).xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Release (TrollStore).xcconfig"; sourceTree = "<group>"; };
 		B9FF01E92977DD0000B49B00 /* Release (Beta, TrollStore).xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Release (Beta, TrollStore).xcconfig"; sourceTree = "<group>"; };
+		CA04FB6122848250DDBCC450 /* BundledScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BundledScript.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/BundledScript.swift"; sourceTree = SOURCE_ROOT; };
+		CBDCDA09107E3E4AD91EB106 /* StikJITManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StikJITManager.swift; sourceTree = "<group>"; };
+		E1D2D2FDA0650F46CC4503C2 /* DDISession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DDISession.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/DDISession.swift"; sourceTree = SOURCE_ROOT; };
+		E3B76F3465C2C643D991679A /* JITEnabler.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = JITEnabler.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		F33FAE5304A06A9D33FB135F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		F4DD8285C5840A40C82AA091 /* StikJITExtensionLauncher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = StikJITExtensionLauncher.h; sourceTree = "<group>"; };
+		F845EE5887C3F5B62139E67F /* StikJITError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StikJITError.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/StikJITError.swift"; sourceTree = SOURCE_ROOT; };
+		F8A8952C7410ECC3E945A54E /* StikJITExtensionLauncher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = StikJITExtensionLauncher.m; sourceTree = "<group>"; };
+		FF87CC10F11FDB6F3E0941F4 /* IdeviceFFI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IdeviceFFI.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/IdeviceFFI.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8216EF80211D3DE8072F29F2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				402AB7B55CD933E56F5A1B46 /* Foundation.framework in Frameworks */,
+				DA61591F4210B0651CFF70BB /* JavaScriptCore.framework in Frameworks */,
+				FD05A3D9A1809002080AB853 /* Network.framework in Frameworks */,
+				444C3F0FCA4C026057B1457F /* Security.framework in Frameworks */,
+				DE73032B38DFD8649A943D99 /* CFNetwork.framework in Frameworks */,
+				5A606D32147443DBAD1A5DD1 /* SystemConfiguration.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B96C9A4C2A46C1CE002B5ECF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -612,6 +703,7 @@
 			children = (
 				B9476B2427F23FFE009C0A4B /* libdolphin.dylib */,
 				B900A7B327F2D3AF000361DD /* MoltenVK.xcframework */,
+				2032526AC3E708754CF79AD1 /* libidevice_ffi.a */,
 			);
 			path = Libraries;
 			sourceTree = "<group>";
@@ -1226,6 +1318,7 @@
 				B9476B1D27F1AB0E009C0A4B /* PreprocessorCombine.xcconfig */,
 				B9476B2027F22416009C0A4B /* Release.xcconfig */,
 				B9FF01E72977DCBE00B49B00 /* TrollStore.xcconfig */,
+				4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -1560,6 +1653,12 @@
 				B97C49B5297F8B0D00E30877 /* UniformTypeIdentifiers.framework */,
 				B9FCB7E52898FAC10020E233 /* GameController.framework */,
 				B9D9389D283EF7AD00B290FC /* MetalKit.framework */,
+				90B836CEF66DD389BA7DFC36 /* JavaScriptCore.framework */,
+				8C69D8DA358D57C72EE142FB /* Network.framework */,
+				05416988C370B963F5653000 /* Security.framework */,
+				0A46CB993191C5AA22E27A3D /* CFNetwork.framework */,
+				63E263662986E8C62858AA75 /* SystemConfiguration.framework */,
+				C0F9F39577B8677E27B83F6F /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1607,6 +1706,8 @@
 			children = (
 				B9DC3DF627EFBD2C0084DAA4 /* DolphiniOS.app */,
 				B96C9A4F2A46C1CE002B5ECF /* DolphiniOSTests.xctest */,
+				E3B76F3465C2C643D991679A /* JITEnabler.appex */,
+				E3B76F3465C2C643D991679A /* JITEnabler.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1683,6 +1784,23 @@
 				B9FCB7E32898F4D60020E233 /* JitManager+JitStreamer.m */,
 				B950CFCA2962590600197719 /* JitManager+PTrace.h */,
 				B950CFCB2962590600197719 /* JitManager+PTrace.m */,
+				CBDCDA09107E3E4AD91EB106 /* StikJITManager.swift */,
+				3770D9ACA7BC46B9D2C089DF /* JitManager+StikJIT.swift */,
+				CA04FB6122848250DDBCC450 /* BundledScript.swift */,
+				FF87CC10F11FDB6F3E0941F4 /* IdeviceFFI.swift */,
+				911500DD0CC16F1FAA949A37 /* JITSession.swift */,
+				9BF5095623B61790D4E4F0B9 /* ProcessInfo+TXM.swift */,
+				ABE33DEC1ED32EE76E1C6C20 /* ScriptRunner.swift */,
+				7D913F3F6511ACA28A99B200 /* StikJIT.swift */,
+				F845EE5887C3F5B62139E67F /* StikJITError.swift */,
+				75DC8DD2585483DA18E77900 /* legacy.js */,
+				6FDE11B38032F76E7F9EC446 /* universal.js */,
+				DC1A2EFE0262007A101CFF8D /* JITEnablerExtension */,
+				F4DD8285C5840A40C82AA091 /* StikJITExtensionLauncher.h */,
+				F8A8952C7410ECC3E945A54E /* StikJITExtensionLauncher.m */,
+				E1D2D2FDA0650F46CC4503C2 /* DDISession.swift */,
+				A36A512394FA665642AF6E8C /* DeveloperDiskImageService.swift */,
+				5BB5F8BF832C1EF46796F3C6 /* DDIManager.swift */,
 			);
 			path = Jit;
 			sourceTree = "<group>";
@@ -1723,9 +1841,44 @@
 			path = Alert;
 			sourceTree = "<group>";
 		};
+		C0F9F39577B8677E27B83F6F /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				F33FAE5304A06A9D33FB135F /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		DC1A2EFE0262007A101CFF8D /* JITEnablerExtension */ = {
+			isa = PBXGroup;
+			children = (
+				6BF374E5D4F577E8D1B49431 /* JITEnablerRequestHandler.swift */,
+				7C83E3C7032E870DD08E6F64 /* main.m */,
+			);
+			name = JITEnablerExtension;
+			path = JITEnablerExtension;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		5EC4BDFA0AA54C352390B6AE /* JITEnabler */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 40B68528F176A33478BC0732 /* Build configuration list for PBXNativeTarget "JITEnabler" */;
+			buildPhases = (
+				188585205A264EF1DE061B52 /* Sources */,
+				8216EF80211D3DE8072F29F2 /* Frameworks */,
+				C87E3ED2113C1C231D1F81CE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = JITEnabler;
+			productName = JITEnabler;
+			productReference = E3B76F3465C2C643D991679A /* JITEnabler.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		B96C9A4E2A46C1CE002B5ECF /* DolphiniOSTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B96C9A552A46C1CE002B5ECF /* Build configuration list for PBXNativeTarget "DolphiniOSTests" */;
@@ -1757,11 +1910,13 @@
 				B99137B428829F1400588446 /* Transfer Core Strings to Storyboard Strings */,
 				B9DC3DF427EFBD2C0084DAA4 /* Resources */,
 				B900A7A027F255E0000361DD /* CopyFiles */,
+				F9FD173AA3C68BC3E49F3F0B /* Embed App Extensions */,
 				B97E4B622966227B00B3EE9C /* Upload dSYM */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				18AC26EE9CB9E68BCF2ABEAA /* PBXTargetDependency */,
 			);
 			name = DolphiniOS;
 			packageProductDependencies = (
@@ -1815,6 +1970,7 @@
 			targets = (
 				B9DC3DF527EFBD2C0084DAA4 /* DolphiniOS */,
 				B96C9A4E2A46C1CE002B5ECF /* DolphiniOSTests */,
+				5EC4BDFA0AA54C352390B6AE /* JITEnabler */,
 			);
 		};
 /* End PBXProject section */
@@ -1868,6 +2024,15 @@
 				B933EDC327F8E215004D7DD7 /* Assets.xcassets in Resources */,
 				B9D93892283DE63800B290FC /* Emulation.storyboard in Resources */,
 				B9114FA52894E0C800B9C57A /* NKitWarning.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C87E3ED2113C1C231D1F81CE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF99EC6AA3A6981EE8B76B5A /* legacy.js in Resources */,
+				C9380003D02781F71A5505E4 /* universal.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1990,6 +2155,24 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		188585205A264EF1DE061B52 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				79586B1E0A77025C9FD40B41 /* BundledScript.swift in Sources */,
+				5E4809C1A0479998B52B9CAD /* IdeviceFFI.swift in Sources */,
+				8523DE84AB3C6066401C2459 /* JITSession.swift in Sources */,
+				57E174338760848870627C22 /* ProcessInfo+TXM.swift in Sources */,
+				0C9F05BE6CF6E36FC6552B15 /* ScriptRunner.swift in Sources */,
+				ACA1679CFAB09674DB8E06C8 /* StikJIT.swift in Sources */,
+				12B74E80A6A36926DF9A8432 /* StikJITError.swift in Sources */,
+				4FFC06733A954119961CC7FD /* JITEnablerRequestHandler.swift in Sources */,
+				0ABB5E4CCEEEDBCD2D8D2B75 /* main.m in Sources */,
+				4ECD0F45FAB10DEF2C31334D /* DDISession.swift in Sources */,
+				911F905600B448977639A62C /* DeveloperDiskImageService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B96C9A4B2A46C1CE002B5ECF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2016,6 +2199,8 @@
 				B9FCB7BE28967C130020E233 /* JitAcquisitionService.swift in Sources */,
 				B9661F362D23190300FB2AAB /* MappingInputDisplayInputCell.m in Sources */,
 				B9FCB7B9289670830020E233 /* JitManager.m in Sources */,
+				D16E73DFF7987A6CDB79AD0E /* StikJITManager.swift in Sources */,
+				620249E7FE8CEBC155116D2A /* JitManager+StikJIT.swift in Sources */,
 				B99137882881486200588446 /* WiiSystemLanguageViewController.mm in Sources */,
 				B900A7CF27F4DB9A000361DD /* SoftwareListCell.swift in Sources */,
 				B939872A28800BA2008E8E47 /* AudioBackendCell.m in Sources */,
@@ -2141,12 +2326,28 @@
 				B95AC52E2D29C49F0048E48B /* AudioSessionCategoryService.swift in Sources */,
 				B97E4B532965011C00B3EE9C /* FirebaseService.mm in Sources */,
 				B9398727288009D0008E8E47 /* AudioBackendViewController.mm in Sources */,
+				E0330A5A9DC372F70C6DA286 /* StikJITExtensionLauncher.m in Sources */,
+				233A0F9C37C9B95888B38707 /* BundledScript.swift in Sources */,
+				89528D612625954D14BAA2D8 /* IdeviceFFI.swift in Sources */,
+				E549D0ACB0DBF2590C7C33AC /* JITSession.swift in Sources */,
+				23C9C364A79572842B78A3B6 /* ProcessInfo+TXM.swift in Sources */,
+				0C255450097EA1AC3768A98A /* ScriptRunner.swift in Sources */,
+				6189536A53E6991E45FA74B6 /* StikJIT.swift in Sources */,
+				AC6756A358C337596B4037D9 /* StikJITError.swift in Sources */,
+				BC57620FAAF42BE6FD2B5B31 /* DDISession.swift in Sources */,
+				CAF13182D2D61F3FBA8596EA /* DeveloperDiskImageService.swift in Sources */,
+				26D300A3AC24D2577DDEF559 /* DDIManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		18AC26EE9CB9E68BCF2ABEAA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5EC4BDFA0AA54C352390B6AE /* JITEnabler */;
+			targetProxy = 1DF2F7B6A3112E50F02FB48D /* PBXContainerItemProxy */;
+		};
 		B96C9A542A46C1CE002B5ECF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B9DC3DF527EFBD2C0084DAA4 /* DolphiniOS */;
@@ -2227,6 +2428,46 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		084C65370DCD3218EB000280 /* Release (Jailbroken) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release (Jailbroken)";
+		};
+		1A41962069AC086CF7118A5B /* Debug (Jailbroken) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Debug (Jailbroken)";
+		};
+		2A271C3DB12B2871A5E2339B /* Release (Non-Jailbroken) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release (Non-Jailbroken)";
+		};
+		7619C0F4EC75E7F66C479351 /* Release (Beta, Non-Jailbroken) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release (Beta, Non-Jailbroken)";
+		};
+		93E449C2961ECB7DF4D223BB /* Release (Beta, Jailbroken) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release (Beta, Jailbroken)";
+		};
 		B96C9A562A46C1CE002B5ECF /* Debug (Non-Jailbroken) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3533,9 +3774,48 @@
 			};
 			name = "Release (Beta, TrollStore)";
 		};
+		C3811DD0788E58D66FE83AEA /* Release (TrollStore) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release (TrollStore)";
+		};
+		C61991B2FC46FF25FE78A8D5 /* Debug (Non-Jailbroken) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Debug (Non-Jailbroken)";
+		};
+		DF15F5E3D5295A6C01D89912 /* Release (Beta, TrollStore) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F274A73790F056297CA1FEA /* JITEnablerExtension.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release (Beta, TrollStore)";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		40B68528F176A33478BC0732 /* Build configuration list for PBXNativeTarget "JITEnabler" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C61991B2FC46FF25FE78A8D5 /* Debug (Non-Jailbroken) */,
+				1A41962069AC086CF7118A5B /* Debug (Jailbroken) */,
+				2A271C3DB12B2871A5E2339B /* Release (Non-Jailbroken) */,
+				7619C0F4EC75E7F66C479351 /* Release (Beta, Non-Jailbroken) */,
+				084C65370DCD3218EB000280 /* Release (Jailbroken) */,
+				C3811DD0788E58D66FE83AEA /* Release (TrollStore) */,
+				93E449C2961ECB7DF4D223BB /* Release (Beta, Jailbroken) */,
+				DF15F5E3D5295A6C01D89912 /* Release (Beta, TrollStore) */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B96C9A552A46C1CE002B5ECF /* Build configuration list for PBXNativeTarget "DolphiniOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Source/iOS/App/DolphiniOS.xcodeproj/project.pbxproj
+++ b/Source/iOS/App/DolphiniOS.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		E0330A5A9DC372F70C6DA286 /* StikJITExtensionLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A8952C7410ECC3E945A54E /* StikJITExtensionLauncher.m */; };
 		E549D0ACB0DBF2590C7C33AC /* JITSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911500DD0CC16F1FAA949A37 /* JITSession.swift */; };
 		EF99EC6AA3A6981EE8B76B5A /* legacy.js in Resources */ = {isa = PBXBuildFile; fileRef = 75DC8DD2585483DA18E77900 /* legacy.js */; };
+		FA2CE0CDAD2162BC62DDB203 /* JitManager+StikDebugURLScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1F8632881506353AA9F2CF /* JitManager+StikDebugURLScheme.swift */; };
 		FD05A3D9A1809002080AB853 /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C69D8DA358D57C72EE142FB /* Network.framework */; };
 /* End PBXBuildFile section */
 
@@ -650,6 +651,7 @@
 		CBDCDA09107E3E4AD91EB106 /* StikJITManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StikJITManager.swift; sourceTree = "<group>"; };
 		E1D2D2FDA0650F46CC4503C2 /* DDISession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DDISession.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/DDISession.swift"; sourceTree = SOURCE_ROOT; };
 		E3B76F3465C2C643D991679A /* JITEnabler.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = JITEnabler.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF1F8632881506353AA9F2CF /* JitManager+StikDebugURLScheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "JitManager+StikDebugURLScheme.swift"; sourceTree = "<group>"; };
 		F33FAE5304A06A9D33FB135F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		F4DD8285C5840A40C82AA091 /* StikJITExtensionLauncher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = StikJITExtensionLauncher.h; sourceTree = "<group>"; };
 		F845EE5887C3F5B62139E67F /* StikJITError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StikJITError.swift; path = "../../../Externals/StikJIT-iOS/StikJIT/Sources/StikJITError.swift"; sourceTree = SOURCE_ROOT; };
@@ -1801,6 +1803,7 @@
 				E1D2D2FDA0650F46CC4503C2 /* DDISession.swift */,
 				A36A512394FA665642AF6E8C /* DeveloperDiskImageService.swift */,
 				5BB5F8BF832C1EF46796F3C6 /* DDIManager.swift */,
+				EF1F8632881506353AA9F2CF /* JitManager+StikDebugURLScheme.swift */,
 			);
 			path = Jit;
 			sourceTree = "<group>";
@@ -2337,6 +2340,7 @@
 				BC57620FAAF42BE6FD2B5B31 /* DDISession.swift in Sources */,
 				CAF13182D2D61F3FBA8596EA /* DeveloperDiskImageService.swift in Sources */,
 				26D300A3AC24D2577DDEF559 /* DDIManager.swift in Sources */,
+				FA2CE0CDAD2162BC62DDB203 /* JitManager+StikDebugURLScheme.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/iOS/App/DolphiniOS/UI/Emulation/JitWait/JitWait.xib
+++ b/Source/iOS/App/DolphiniOS/UI/Emulation/JitWait/JitWait.xib
@@ -11,6 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="JitWaitViewController">
             <connections>
+                <outlet property="stikJITButton" destination="StK-JT-bt1" id="StK-JT-ot1"/>
                 <outlet property="view" destination="r55-Fn-aBI" id="r9r-Zd-Dn7"/>
             </connections>
         </placeholder>
@@ -85,6 +86,25 @@ For more information, tap "Help".</string>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="np2-xh-cqO">
                                     <rect key="frame" x="20" y="20" width="335" height="155"/>
                                     <subviews>
+                                        <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="StK-JT-bt1" userLabel="Enable JIT with StikJIT">
+                                            <rect key="frame" x="0.0" y="0.0" width="335" height="45"/>
+                                            <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="45" id="StK-JT-ht1"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                            <state key="normal" title="Enable JIT with StikJIT">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                    <integer key="value" value="10"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                            <connections>
+                                                <action selector="stikJITPressed:" destination="-1" eventType="touchUpInside" id="StK-JT-ac1"/>
+                                            </connections>
+                                        </button>
                                         <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sCq-RD-iKA" userLabel="Help">
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="45"/>
                                             <color key="backgroundColor" systemColor="linkColor"/>
@@ -187,6 +207,9 @@ For more information, tap "Help".</string>
         </systemColor>
         <systemColor name="systemOrangeColor">
             <color red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGreenColor">
+            <color red="0.20392156862745098" green="0.78039215686274506" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
             <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Source/iOS/App/DolphiniOS/UI/Settings/About/AboutSettings.storyboard
+++ b/Source/iOS/App/DolphiniOS/UI/Settings/About/AboutSettings.storyboard
@@ -78,6 +78,17 @@
                                                     <action selector="sourceCodePressed:" destination="jWY-Tc-15b" eventType="touchUpInside" id="Usw-dr-pgF"/>
                                                 </connections>
                                             </button>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="In-app JIT enablement is powered by StikJIT." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Stk-Cr-lbl" userLabel="StikJIT Credit">
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Stk-Cr-btn">
+                                                <state key="normal" title="StikJIT"/>
+                                                <connections>
+                                                    <action selector="stikJITCreditPressed:" destination="jWY-Tc-15b" eventType="touchUpInside" id="Stk-Cr-act"/>
+                                                </connections>
+                                            </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zla-wR-sFe">
                                                 <rect key="frame" x="0.0" y="538" width="335" height="0.0"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/Source/iOS/App/DolphiniOS/UI/Settings/Debug/DebugSettings.storyboard
+++ b/Source/iOS/App/DolphiniOS/UI/Settings/Debug/DebugSettings.storyboard
@@ -248,6 +248,95 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Stk-JIT-sw01">
+                                        <rect key="frame" x="16" y="627.5" width="343" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Stk-JIT-sw01" id="Stk-JIT-cv01">
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Self-Enable JIT (StikJIT)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Stk-JIT-lb01">
+                                                    <rect key="frame" x="16" y="11" width="254" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Stk-JIT-sw02" customClass="DOLUIKitSwitch">
+                                                    <rect key="frame" x="278" y="6.5" width="51" height="31"/>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Stk-JIT-lb01" firstAttribute="top" secondItem="Stk-JIT-cv01" secondAttribute="topMargin" id="Stk-JIT-c001"/>
+                                                <constraint firstItem="Stk-JIT-sw02" firstAttribute="leading" secondItem="Stk-JIT-lb01" secondAttribute="trailing" constant="8" id="Stk-JIT-c002"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Stk-JIT-lb01" secondAttribute="bottom" id="Stk-JIT-c003"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Stk-JIT-sw02" secondAttribute="trailing" id="Stk-JIT-c004"/>
+                                                <constraint firstItem="Stk-JIT-lb01" firstAttribute="leading" secondItem="Stk-JIT-cv01" secondAttribute="leadingMargin" id="Stk-JIT-c005"/>
+                                                <constraint firstItem="Stk-JIT-sw02" firstAttribute="centerY" secondItem="Stk-JIT-cv01" secondAttribute="centerY" id="Stk-JIT-c006"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Stk-JIT-im01">
+                                        <rect key="frame" x="16" y="671" width="343" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Stk-JIT-im01" id="Stk-JIT-cv02">
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Import Pairing File" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Stk-JIT-lb02">
+                                                    <rect key="frame" x="16" y="11" width="254" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="linkColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Not Imported" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Stk-JIT-lb03">
+                                                    <rect key="frame" x="278" y="11" width="49" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Stk-JIT-lb02" secondAttribute="bottom" id="Stk-JIT-c007"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Stk-JIT-lb03" secondAttribute="bottom" id="Stk-JIT-c008"/>
+                                                <constraint firstItem="Stk-JIT-lb03" firstAttribute="leading" secondItem="Stk-JIT-lb02" secondAttribute="trailing" constant="8" id="Stk-JIT-c009"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Stk-JIT-lb03" secondAttribute="trailing" id="Stk-JIT-c010"/>
+                                                <constraint firstItem="Stk-JIT-lb02" firstAttribute="leading" secondItem="Stk-JIT-cv02" secondAttribute="leadingMargin" id="Stk-JIT-c011"/>
+                                                <constraint firstItem="Stk-JIT-lb02" firstAttribute="top" secondItem="Stk-JIT-cv02" secondAttribute="topMargin" id="Stk-JIT-c012"/>
+                                                <constraint firstItem="Stk-JIT-lb03" firstAttribute="top" secondItem="Stk-JIT-cv02" secondAttribute="topMargin" id="Stk-JIT-c013"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Stk-DDI-mn01">
+                                        <rect key="frame" x="16" y="671" width="343" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Stk-DDI-mn01" id="Stk-DDI-cv01">
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Delete Cached DDI" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Stk-DDI-lb01">
+                                                    <rect key="frame" x="16" y="11" width="254" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="linkColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Not Present" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Stk-DDI-lb02">
+                                                    <rect key="frame" x="278" y="11" width="49" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Stk-DDI-lb01" secondAttribute="bottom" id="Stk-DDI-c001"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Stk-DDI-lb02" secondAttribute="bottom" id="Stk-DDI-c002"/>
+                                                <constraint firstItem="Stk-DDI-lb02" firstAttribute="leading" secondItem="Stk-DDI-lb01" secondAttribute="trailing" constant="8" id="Stk-DDI-c003"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Stk-DDI-lb02" secondAttribute="trailing" id="Stk-DDI-c004"/>
+                                                <constraint firstItem="Stk-DDI-lb01" firstAttribute="leading" secondItem="Stk-DDI-cv01" secondAttribute="leadingMargin" id="Stk-DDI-c005"/>
+                                                <constraint firstItem="Stk-DDI-lb01" firstAttribute="top" secondItem="Stk-DDI-cv01" secondAttribute="topMargin" id="Stk-DDI-c006"/>
+                                                <constraint firstItem="Stk-DDI-lb02" firstAttribute="top" secondItem="Stk-DDI-cv01" secondAttribute="topMargin" id="Stk-DDI-c007"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="CoY-ea-Rfl">
                                         <rect key="frame" x="16" y="627.5" width="343" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
@@ -329,6 +418,9 @@
                         <outlet property="mfiSwitch" destination="v1R-bY-GZa" id="hj8-yD-8f9"/>
                         <outlet property="syncOnIdleSkipSwitch" destination="rAe-2m-46S" id="zkQ-os-2Th"/>
                         <outlet property="userFolderPathLabel" destination="v9G-Mi-XiD" id="fDJ-3u-yQY"/>
+                        <outlet property="selfEnableJitSwitch" destination="Stk-JIT-sw02" id="Stk-JIT-c014"/>
+                        <outlet property="importPairingFileStatusLabel" destination="Stk-JIT-lb03" id="Stk-JIT-c015"/>
+                        <outlet property="ddiMounterStatusLabel" destination="Stk-DDI-lb02" id="Stk-DDI-c008"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="adV-2q-gSQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Source/iOS/App/Project/Config/Common.xcconfig
+++ b/Source/iOS/App/Project/Config/Common.xcconfig
@@ -1,7 +1,9 @@
 // Copyright 2022 DolphiniOS Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-LIBRARY_SEARCH_PATHS = $(inherited) "$(SRCROOT)/../../../build-$(PLATFORM_NAME)-$(DOL_CORE_BUILD_TARGET)/Source/iOS/Library"
-HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../Externals/mbedtls/include" "$(SRCROOT)/../../../Externals/fmt/fmt/include" "$(SRCROOT)/../../../Externals/soundtouch/" "$(SRCROOT)/../../../Externals/picojson/"
+LIBRARY_SEARCH_PATHS = $(inherited) "$(SRCROOT)/../../../build-$(PLATFORM_NAME)-$(DOL_CORE_BUILD_TARGET)/Source/iOS/Library" "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice"
+HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../Externals/mbedtls/include" "$(SRCROOT)/../../../Externals/fmt/fmt/include" "$(SRCROOT)/../../../Externals/soundtouch/" "$(SRCROOT)/../../../Externals/picojson/" "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice"
 USER_HEADER_SEARCH_PATHS = $(inherited) "$(SRCROOT)/../../Core/**" "$(SRCROOT)/../Library/"
 SWIFT_OBJC_BRIDGING_HEADER = Common/Swift/BridgingHeader.h
+SWIFT_INCLUDE_PATHS = $(inherited) "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice"
+OTHER_LDFLAGS = $(inherited) -force_load "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice/libidevice_ffi.a"

--- a/Source/iOS/App/Project/Config/JITEnablerExtension.xcconfig
+++ b/Source/iOS/App/Project/Config/JITEnablerExtension.xcconfig
@@ -1,0 +1,29 @@
+// Copyright 2025 DolphiniOS Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "BundleIdentifier.xcconfig"
+#include "DevelopmentTeam.xcconfig"
+
+PRODUCT_NAME = JITEnabler
+IPHONEOS_DEPLOYMENT_TARGET = 17.4
+TARGETED_DEVICE_FAMILY = 1,2
+SWIFT_VERSION = 5.0
+SKIP_INSTALL = YES
+CODE_SIGN_STYLE = Automatic
+
+INFOPLIST_FILE = Common/Jit/JITEnablerExtension/Info.plist
+CODE_SIGN_ENTITLEMENTS = Common/Jit/JITEnablerExtension/JITEnablerExtension.entitlements
+
+LIBRARY_SEARCH_PATHS = $(inherited) "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice"
+HEADER_SEARCH_PATHS = $(inherited) "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice"
+SWIFT_INCLUDE_PATHS = $(inherited) "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice"
+OTHER_LDFLAGS = $(inherited) -force_load "$(SRCROOT)/../../../Externals/StikJIT-iOS/StikJIT/idevice/libidevice_ffi.a"
+
+PRODUCT_BUNDLE_IDENTIFIER[config=Debug (Non-Jailbroken)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME)-njb-debug.JITEnabler
+PRODUCT_BUNDLE_IDENTIFIER[config=Debug (Jailbroken)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME)-debug.JITEnabler
+PRODUCT_BUNDLE_IDENTIFIER[config=Release (Non-Jailbroken)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME)-njb.JITEnabler
+PRODUCT_BUNDLE_IDENTIFIER[config=Release (Beta, Non-Jailbroken)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME)-njb-patreon-beta.JITEnabler
+PRODUCT_BUNDLE_IDENTIFIER[config=Release (Jailbroken)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME).JITEnabler
+PRODUCT_BUNDLE_IDENTIFIER[config=Release (Beta, Jailbroken)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME)-patreon-beta.JITEnabler
+PRODUCT_BUNDLE_IDENTIFIER[config=Release (TrollStore)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME)-ts.JITEnabler
+PRODUCT_BUNDLE_IDENTIFIER[config=Release (Beta, TrollStore)] = $(DOL_PBID_ORGANIZATION_IDENTIFIER).$(DOL_PBID_APP_NAME)-ts-patreon-beta.JITEnabler


### PR DESCRIPTION
- Adds support for built-in JIT enabling on iOS 17.4+ via [StikJIT](https://github.com/StephenDev0/StikJIT). Requires a pairing file and LocalDevVPN, mounts DDI, enables JIT, and runs scripts. Pros: this is as close to seamless as it can get, and better for UX to be self-contained. Does everything StikDebug currently does and easier. We hope for this to become the new standard. Cons: the extension uses an extra app id, it doesn't work in LiveContainer yet due to lack of NSExtension handling, and you have to bundle idevice which increases binary size (about 5.5mb from the previous 16.7mb, about 33% bigger).
- Adds auto JIT enabling for StikDebug via url scheme on game launch if StikDebug is present and device is running iOS/iPadOS 17.4+
- Adds a workflow for building unsigned ipas for testing on GitHub-hosted runners (intended to make testing changes on forked repos easier and faster). It should automatically skip itself in favor of your self-hosted runner on this repo.