### PR TITLE
deliver controller input to the game while emulating

### DIFF
--- a/Source/iOS/App/Common/UI/Emulation/EmulationViewController.h
+++ b/Source/iOS/App/Common/UI/Emulation/EmulationViewController.h
@@ -4,13 +4,15 @@
 #import <UIKit/UIKit.h>
 #import <MetalKit/MetalKit.h>
 
+#import <GameController/GameController.h>
+
 #import "Swift.h"
 
 @class EmulationBootParameter;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EmulationViewController : UIViewController <JitWaitViewControllerDelegate, NKitWarningViewControllerDelegate>
+@interface EmulationViewController : GCEventViewController <JitWaitViewControllerDelegate, NKitWarningViewControllerDelegate>
 
 @property (weak, nonatomic) IBOutlet UIView* rendererView;
 

--- a/Source/iOS/App/DolphiniOS/UI/Emulation/EmulationiOSViewController.mm
+++ b/Source/iOS/App/DolphiniOS/UI/Emulation/EmulationiOSViewController.mm
@@ -19,6 +19,7 @@
 #import "Core/State.h"
 #import "Core/System.h"
 
+#import "InputCommon/ControllerInterface/ControllerInterface.h"
 #import "InputCommon/InputConfig.h"
 
 #import "VideoCommon/Present.h"
@@ -48,6 +49,13 @@ typedef NS_ENUM(NSInteger, DOLEmulationVisibleTouchPad) {
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
+  // iOS otherwise consumes the face buttons (A/B/X/Y) for UIKit menu navigation.
+  self.controllerUserInteractionEnabled = NO;
+
+  // Devices are otherwise only populated at app launch and in the mapping screen,
+  // leaving a controller connected after launch absent when the game boots.
+  g_controller_interface.RefreshDevices();
 
   for (int i = 0; i < [self.touchPads count]; i++) {
     TCView* padView = self.touchPads[i];


### PR DESCRIPTION
A connected controller does nothing during gameplay on recent iOS versions, even though the mapping screen registers every button. Two separate things go wrong, and both have to be fixed for input to reach the emulated pad.

Closes OatmealDome/dolphin-ios#226

### What

- `EmulationViewController` derives from `GCEventViewController`, and the emulation screen sets `controllerUserInteractionEnabled = NO`. While controller user interaction is on, iOS routes the face buttons (A/B/X/Y) into UIKit menu-focus navigation and they never reach the game. Sticks are unaffected, which is why input looks half-working. This is scoped to the emulation view controller, so controller-driven UI navigation elsewhere in the app is untouched.
- `RefreshDevices()` runs when emulation starts. Devices are otherwise only populated at app launch and in the mapping screen, so a controller connected after launch isn't in the `ControllerInterface` when the game boots. `GCPad::GetInput` then sees the pad's default device as disconnected and returns before reading any buttons.

### Tests

Verified on-device (iPhone, iOS 26) across TestFlight builds: buttons and sticks drive the emulated GameCube pad in-game, and autorotation and the rest of the app's UI behave as before.

Diagnosis was confirmed by reading `GCController` state directly on the main thread during gameplay: the left stick's axis value updated live while `buttonA.isPressed` stayed `false`, which isolates the loss to iOS consuming the face buttons rather than anything in Dolphin's input stack.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
